### PR TITLE
changed rpm to use -Uvh and 1.1-6 version - Issue #1

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -73,7 +73,7 @@ data:
         exit 1
     fi
 
-    PACKAGE="log4j-cve-2021-44228-hotpatch-1.1-3.$RPM_TYPE.noarch"
+    PACKAGE="log4j-cve-2021-44228-hotpatch-1.1-6.$RPM_TYPE.noarch"
     FILE="/tmp/install/$PACKAGE.rpm"
     echo "Detecting RPM file: $FILE"
     if test -f "$FILE"; then
@@ -84,7 +84,7 @@ data:
     fi
 
     echo "Installing $PACKAGE"
-    eval "rpm -ivh $FILE"
+    eval "rpm -Uvh $FILE"
     echo "Verifying $PACKAGE"
     OUTPUT=`eval "rpm -V $PACKAGE"`
     if [[ -z $OUTPUT ]]; then


### PR DESCRIPTION
Issue #1 

- Changed `rpm -ivh` to `rpm -Uvh` to install and/or update in place RPMs.
- Changed version/release from `1.1-3` to `1.1-6`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
