### PR TITLE
Fix for Issue #21 - Debian/Ubuntu support

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -60,38 +60,79 @@ data:
     #!/bin/bash
 
     OS_TYPE=`uname -a`
-    RPM_TYPE=""
-    echo "Detecting OS..."
+    VERSION_AMZN="1.1-12"
+    PKG_AL1="log4j-cve-2021-44228-hotpatch-$VERSION_AMZN.amzn1.noarch"
+    PKG_AL2="log4j-cve-2021-44228-hotpatch-$VERSION_AMZN.amzn2.noarch"
+    VERSION_DEBIAN="1.1.12" #Change for debian versions
+    PKG_DEBIAN="log4j-cve-2021-44228-hotpatch"
+    ARCH_DEBIAN="all"
+    STATUS_OK_DEBIAN="install ok installed"
+
+    check_file() {
+        echo "Detecting patch file: $1 ..."
+        if test -f "$1"; then
+            echo "$1 exists."
+        else
+            echo "ERROR: $1 does not exist."
+            exit 1
+        fi
+    }
+
+    install_rpm() {
+        echo "Installing $1 ..."
+        eval "rpm -Uvh $1"
+    }
+
+    install_dpkg() {
+        echo "Installing $1 ..."
+        eval "dpkg -i $1"
+    }
+
+    verify_rpm() {
+        echo "Verifying $1 package ..."
+        local OUTPUT=`eval "rpm -V $1"`
+        if [[ -z $OUTPUT ]]; then
+            echo "$1 installed and verified"
+        else
+            echo "$1 could not be verified"
+            echo "$OUTPUT"
+            exit 1
+        fi
+    }
+
+    #Must verify package and version
+    verify_dpkg() {
+        echo "Verifying $1 package, version $2 ..."
+        local OUTPUT=`eval "dpkg -s $1"`
+        if [[ $OUTPUT =~ "Status: $STATUS_OK_DEBIAN" ]] && [[ $OUTPUT =~ "Version: $2" ]]; then
+            echo "$1, version $2, installed and verified"
+        else
+            echo "$1, version $2,  could not be verified"
+            echo "$OUTPUT"
+            exit 1
+        fi
+    }
+
+    echo "Detecting OS ..."
     if [[ "$OS_TYPE" =~ "amzn1" ]]; then
-        RPM_TYPE="amzn1"
-        echo "OS Matched $RPM_TYPE"
+        echo "OS Matched amzn1 - $OS_TYPE"
+        check_file "/tmp/install/$PKG_AL1.rpm"
+        install_rpm "/tmp/install/$PKG_AL1.rpm"
+        verify_rpm "$PKG_AL1"
     elif [[ "$OS_TYPE" =~ "amzn2" ]]; then
-        RPM_TYPE="amzn2"
-        echo "OS Matched $RPM_TYPE"
+        PKG_TYPE="amzn2"
+        echo "OS Matched amzn2 - $OS_TYPE"
+        SUFFIX=".rpm"
+        check_file "/tmp/install/$PKG_AL2.rpm"
+        install_rpm "/tmp/install/$PKG_AL2.rpm"
+        verify_rpm "$PKG_AL2"
+    elif [[ "$OS_TYPE" =~ "Debian" ]] || [[ "$OS_TYPE" =~ "Ubuntu" ]]; then
+        echo "OS Matched Debian - $OS_TYPE"
+        check_file "/tmp/install/${PKG_DEBIAN}_${VERSION_DEBIAN}_${ARCH_DEBIAN}.deb"
+        install_dpkg "/tmp/install/${PKG_DEBIAN}_${VERSION_DEBIAN}_${ARCH_DEBIAN}.deb"
+        verify_dpkg "$PKG_DEBIAN" "$VERSION_DEBIAN"
     else
         echo "No OS match for $OS_TYPE"
-        exit 1
-    fi
-
-    PACKAGE="log4j-cve-2021-44228-hotpatch-1.1-12.$RPM_TYPE.noarch"
-    FILE="/tmp/install/$PACKAGE.rpm"
-    echo "Detecting RPM file: $FILE"
-    if test -f "$FILE"; then
-        echo "$FILE exists."
-    else
-        echo "ERROR: $FILE does not exist."
-        exit 1
-    fi
-
-    echo "Installing $PACKAGE"
-    eval "rpm -Uvh $FILE"
-    echo "Verifying $PACKAGE"
-    OUTPUT=`eval "rpm -V $PACKAGE"`
-    if [[ -z $OUTPUT ]]; then
-        echo "$PACKAGE installed and verified"
-    else
-        echo "$PACKAGE could not be verified"
-        echo "$OUTPUT"
         exit 1
     fi
 ---
@@ -134,7 +175,7 @@ spec:
       hostPID: true
       restartPolicy: Always 
       initContainers:
-      - image: public.ecr.aws/aws-containers/kubernetes-log4j-cve-2021-44228-mitigation:v0.0.12
+      - image: public.ecr.aws/aws-containers/kubernetes-log4j-cve-2021-44228-mitigation:v0.0.12-debian
         name: node-patch-installer
         securityContext:
           privileged: true

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -60,10 +60,10 @@ data:
     #!/bin/bash
 
     OS_TYPE=`uname -a`
-    VERSION_AMZN="1.1-12"
+    VERSION_AMZN="1.1-12" #Change for package versions
     PKG_AL1="log4j-cve-2021-44228-hotpatch-$VERSION_AMZN.amzn1.noarch"
     PKG_AL2="log4j-cve-2021-44228-hotpatch-$VERSION_AMZN.amzn2.noarch"
-    VERSION_DEBIAN="1.1.12" #Change for debian versions
+    VERSION_DEBIAN="1.1.12" #Change for package versions
     PKG_DEBIAN="log4j-cve-2021-44228-hotpatch"
     ARCH_DEBIAN="all"
     STATUS_OK_DEBIAN="install ok installed"

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -122,7 +122,6 @@ data:
     elif [[ "$OS_TYPE" =~ "amzn2" ]]; then
         PKG_TYPE="amzn2"
         echo "OS Matched amzn2 - $OS_TYPE"
-        SUFFIX=".rpm"
         check_file "/tmp/install/$PKG_AL2.rpm"
         install_rpm "/tmp/install/$PKG_AL2.rpm"
         verify_rpm "$PKG_AL2"


### PR DESCRIPTION
*Issue #, if available:* #21

*Description of changes:* Fixes #21 

Modified `install.sh` in the `node-patch-installer-script` configmap of the `daemonset.yaml` to handle Debian/Ubuntu Linux  distros, as well AL1/2.

Modified image field for daemonset to use the `public.ecr.aws/aws-containers/kubernetes-log4j-cve-2021-44228-mitigation:v0.0.12-debian` image.

Test results in EKS cluster with Ubuntu and AL2 managed node groups:
```
Detecting OS ...
OS Matched Debian - Linux node-patch-installer-2vgbb 5.11.0-1022-aws #23~20.04.1-Ubuntu SMP Mon Nov 15 14:03:19 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
Detecting patch file: /tmp/install/log4j-cve-2021-44228-hotpatch_1.1.12_all.deb ...
/tmp/install/log4j-cve-2021-44228-hotpatch_1.1.12_all.deb exists.
Installing /tmp/install/log4j-cve-2021-44228-hotpatch_1.1.12_all.deb ...
(Reading database ... 94685 files and directories currently installed.)
Preparing to unpack .../log4j-cve-2021-44228-hotpatch_1.1.12_all.deb ...
Unpacking log4j-cve-2021-44228-hotpatch (1.1.12) over (1.1.12) ...
Setting up log4j-cve-2021-44228-hotpatch (1.1.12) ...
Verifying log4j-cve-2021-44228-hotpatch package, version 1.1.12 ...
log4j-cve-2021-44228-hotpatch, version 1.1.12, installed and verified
Waiting for 30 seconds...
Task Completed
```
```
Detecting OS ...
OS Matched amzn2 - Linux node-patch-installer-g6lbm 5.4.162-86.275.amzn2.x86_64 #1 SMP Tue Nov 30 20:47:40 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
Detecting patch file: /tmp/install/log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch.rpm ...
/tmp/install/log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch.rpm exists.
Installing /tmp/install/log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch.rpm ...
Preparing...                          ########################################
	package log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch is already installed
Verifying log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch package ...
log4j-cve-2021-44228-hotpatch-1.1-12.amzn2.noarch installed and verified
Waiting for 30 seconds...
Task Completed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
